### PR TITLE
Stock Flow Raster Fixes

### DIFF
--- a/src/Runtime/StockFlowTransformer.Initialize.cs
+++ b/src/Runtime/StockFlowTransformer.Initialize.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Collections.Generic;
 using SyncroSim.Core;
+using SyncroSim.StochasticTime;
 
 namespace SyncroSim.STSimStockFlow
 {

--- a/src/Runtime/StockFlowTransformer.Output.cs
+++ b/src/Runtime/StockFlowTransformer.Output.cs
@@ -383,7 +383,14 @@ namespace SyncroSim.STSimStockFlow
 
 														foreach (Cell c in this.m_STSimTransformer.Cells)
 														{
-																arr[c.CellId] = rec.Data[c.CollectionIndex];
+																if (rec.Data[c.CollectionIndex] == Spatial.DefaultNoDataValue)
+                                {
+																		arr[c.CellId] = 0;
+                                }
+                                else
+                                {
+																		arr[c.CellId] = rec.Data[c.CollectionIndex];
+																}
 														}
 
 														rastFlowType.ScaleFloatCells(l.Value);
@@ -554,10 +561,7 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (Cell c in this.STSimTransformer.Cells)
 										{
-												if (values[c.CollectionIndex] != 0)
-                        {
-														arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex]);
-												}
+												arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex]);
 										}
 
 										Spatial.WriteRasterData(

--- a/src/Runtime/StockFlowTransformer.Output.cs
+++ b/src/Runtime/StockFlowTransformer.Output.cs
@@ -554,7 +554,7 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (Cell c in this.STSimTransformer.Cells)
 										{
-												arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex] / this.STSimTransformer.AmountPerCell);
+												arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex]);
 										}
 
 										Spatial.WriteRasterData(
@@ -799,7 +799,10 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														Amount += rec.Data[i];
+														if (rec.Data[i] != Spatial.DefaultNoDataValue)
+														{
+																Amount += rec.Data[i];
+														}
 												}
 										}
 

--- a/src/Runtime/StockFlowTransformer.Output.cs
+++ b/src/Runtime/StockFlowTransformer.Output.cs
@@ -224,7 +224,7 @@ namespace SyncroSim.STSimStockFlow
 								SpatialOutputFlowRecord rec = GetSpatialOutputFlowDictionary()[flowTypeId];
 								float amt = rec.Data[cell.CollectionIndex];
 
-								if (amt.Equals(Spatial.DefaultNoDataValue))
+								if (amt.Equals(Spatial.DefaultNoDataValue) || float.IsNaN(amt))
 								{
 										amt = 0;
 								}
@@ -384,11 +384,11 @@ namespace SyncroSim.STSimStockFlow
 														foreach (Cell c in this.m_STSimTransformer.Cells)
 														{
 																if (rec.Data[c.CollectionIndex] == Spatial.DefaultNoDataValue)
-                                {
+																{
 																		arr[c.CellId] = 0;
-                                }
-                                else
-                                {
+																}
+																else
+																{
 																		arr[c.CellId] = rec.Data[c.CollectionIndex];
 																}
 														}
@@ -444,7 +444,14 @@ namespace SyncroSim.STSimStockFlow
 
 														foreach (Cell c in this.m_STSimTransformer.Cells)
 														{
-																arr[c.CellId] = rec.Data[c.CollectionIndex];
+																if (rec.Data[c.CollectionIndex] == Spatial.DefaultNoDataValue)
+																{
+																		arr[c.CellId] = 0;
+																}
+																else
+																{
+																		arr[c.CellId] = rec.Data[c.CollectionIndex];
+																}
 														}
 
 														rastFlowType.ScaleFloatCells(l.Value);
@@ -617,7 +624,7 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (Cell c in this.STSimTransformer.Cells)
 										{
-												arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex] / this.STSimTransformer.AmountPerCell);
+												arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex]);
 										}
 
 										Spatial.WriteRasterData(
@@ -702,7 +709,10 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (StockTypeLinkage l in g.StockTypeLinkages)
 										{
-											 Amount += Convert.ToSingle(StockAmounts[l.StockType.Id]);
+												if (!float.IsNaN(StockAmounts[l.StockType.Id]))
+												{
+														Amount += Convert.ToSingle(StockAmounts[l.StockType.Id] * l.Value);
+												}
 										}
 
 										Values[i] += Amount / this.m_TotalIterations;
@@ -736,7 +746,7 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (StockTypeLinkage l in g.StockTypeLinkages)
 										{
-												Amount += Convert.ToSingle(StockAmounts[l.StockType.Id]);
+												Amount += Convert.ToSingle(StockAmounts[l.StockType.Id] * l.Value);
 										}
 
 										if ((timestepKey == this.STSimTransformer.MaximumTimestep) && (((timestepKey - this.STSimTransformer.TimestepZero) % this.m_AvgSpatialStockOutputTimesteps) != 0))
@@ -806,9 +816,9 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														if (rec.Data[i] != Spatial.DefaultNoDataValue)
+														if ((rec.Data[i] != Spatial.DefaultNoDataValue) && !float.IsNaN(rec.Data[i]))
 														{
-																Amount += Convert.ToSingle(rec.Data[i]);
+																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
 														}
 												}
 										}
@@ -847,8 +857,11 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														Amount += rec.Data[i];
-												}                    
+														if (rec.Data[i] != Spatial.DefaultNoDataValue)
+														{
+																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
+														}
+												}
 										}
 
 										if ((timestepKey == this.STSimTransformer.MaximumTimestep) && (((timestepKey - this.STSimTransformer.TimestepZero) % this.m_AvgSpatialFlowOutputTimesteps) != 0))
@@ -918,7 +931,10 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														Amount += rec.Data[i];
+														if(rec.Data[i] != Spatial.DefaultNoDataValue)
+														{
+																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
+														}
 												}                     
 										}
 
@@ -956,7 +972,10 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														Amount += rec.Data[i];
+														if (rec.Data[i] != Spatial.DefaultNoDataValue)
+														{
+																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
+														}
 												}                         
 										}
 

--- a/src/Runtime/StockFlowTransformer.Output.cs
+++ b/src/Runtime/StockFlowTransformer.Output.cs
@@ -746,7 +746,10 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (StockTypeLinkage l in g.StockTypeLinkages)
 										{
-												Amount += Convert.ToSingle(StockAmounts[l.StockType.Id] * l.Value);
+												if (!float.IsNaN(StockAmounts[l.StockType.Id]))
+												{
+														Amount += Convert.ToSingle(StockAmounts[l.StockType.Id] * l.Value);
+												}
 										}
 
 										if ((timestepKey == this.STSimTransformer.MaximumTimestep) && (((timestepKey - this.STSimTransformer.TimestepZero) % this.m_AvgSpatialStockOutputTimesteps) != 0))
@@ -857,7 +860,7 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														if (rec.Data[i] != Spatial.DefaultNoDataValue)
+														if ((rec.Data[i] != Spatial.DefaultNoDataValue) && !float.IsNaN(rec.Data[i]))
 														{
 																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
 														}
@@ -931,7 +934,7 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														if(rec.Data[i] != Spatial.DefaultNoDataValue)
+														if((rec.Data[i] != Spatial.DefaultNoDataValue) && !float.IsNaN(rec.Data[i]))
 														{
 																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
 														}
@@ -972,7 +975,7 @@ namespace SyncroSim.STSimStockFlow
 
 												if (rec.HasOutputData)
 												{
-														if (rec.Data[i] != Spatial.DefaultNoDataValue)
+														if ((rec.Data[i] != Spatial.DefaultNoDataValue) && !float.IsNaN(rec.Data[i]))
 														{
 																Amount += Convert.ToSingle(rec.Data[i] * l.Value);
 														}

--- a/src/Runtime/StockFlowTransformer.Output.cs
+++ b/src/Runtime/StockFlowTransformer.Output.cs
@@ -554,7 +554,10 @@ namespace SyncroSim.STSimStockFlow
 
 										foreach (Cell c in this.STSimTransformer.Cells)
 										{
-												arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex]);
+												if (values[c.CollectionIndex] != 0)
+                        {
+														arr[c.CellId] = Convert.ToSingle(values[c.CollectionIndex]);
+												}
 										}
 
 										Spatial.WriteRasterData(
@@ -801,11 +804,11 @@ namespace SyncroSim.STSimStockFlow
 												{
 														if (rec.Data[i] != Spatial.DefaultNoDataValue)
 														{
-																Amount += rec.Data[i];
+																Amount += Convert.ToSingle(rec.Data[i]);
 														}
 												}
 										}
-
+										
 										Values[i] += Amount / this.m_TotalIterations;
 								}
 						}

--- a/src/Runtime/StockFlowTransformer.Utilities.cs
+++ b/src/Runtime/StockFlowTransformer.Utilities.cs
@@ -42,128 +42,128 @@ namespace SyncroSim.STSimStockFlow
 		/// <remarks></remarks>
 		private static Dictionary<int, float> GetStockAmountDictionary(Cell cell)
 		{
-            Dictionary<int, float> StockAmounts = (Dictionary<int, float>)cell.GetAssociatedObject(STOCK_AMOUNT_KEY);
+						Dictionary<int, float> StockAmounts = (Dictionary<int, float>)cell.GetAssociatedObject(STOCK_AMOUNT_KEY);
 
-            if (StockAmounts == null)
-            {
-                StockAmounts = new Dictionary<int, float>();
-                cell.SetAssociatedObject(STOCK_AMOUNT_KEY, StockAmounts);
-            }
+						if (StockAmounts == null)
+						{
+								StockAmounts = new Dictionary<int, float>();
+								cell.SetAssociatedObject(STOCK_AMOUNT_KEY, StockAmounts);
+						}
 
-            return StockAmounts;
-        }
+						return StockAmounts;
+				}
 
-        /// <summary>
-        /// Gets the spatial output flow dictionary
-        /// </summary>
-        /// <returns></returns>
-        /// <remarks>
-        /// We must lazy-load this dictionary because this transformer runs before ST-Sim's
-        /// and so the cell data is not there yet.
-        /// </remarks>
-        private Dictionary<int, SpatialOutputFlowRecord> GetSpatialOutputFlowDictionary()
-        {
-            if (this.m_SpatialOutputFlowDict == null)
-            {
-                this.m_SpatialOutputFlowDict = new Dictionary<int, SpatialOutputFlowRecord>();
+				/// <summary>
+				/// Gets the spatial output flow dictionary
+				/// </summary>
+				/// <returns></returns>
+				/// <remarks>
+				/// We must lazy-load this dictionary because this transformer runs before ST-Sim's
+				/// and so the cell data is not there yet.
+				/// </remarks>
+				private Dictionary<int, SpatialOutputFlowRecord> GetSpatialOutputFlowDictionary()
+				{
+						if (this.m_SpatialOutputFlowDict == null)
+						{
+								this.m_SpatialOutputFlowDict = new Dictionary<int, SpatialOutputFlowRecord>();
 
-                foreach (FlowType ft in this.m_FlowTypes)
-                {
-                    if (ft.OutputFilter.HasFlag(Constants.OutputFilter.Spatial) ||
-                        ft.OutputFilter.HasFlag(Constants.OutputFilter.AvgSpatial))
-                    {
-                        SpatialOutputFlowRecord rec = new SpatialOutputFlowRecord();
+								foreach (FlowType ft in this.m_FlowTypes)
+								{
+										if (ft.OutputFilter.HasFlag(Constants.OutputFilter.Spatial) ||
+												ft.OutputFilter.HasFlag(Constants.OutputFilter.AvgSpatial))
+										{
+												SpatialOutputFlowRecord rec = new SpatialOutputFlowRecord();
 
-                        rec.FlowTypeId = ft.Id;
-                        rec.Data = new float[this.STSimTransformer.Cells.Count];
-                        rec.HasOutputData = false;
+												rec.FlowTypeId = ft.Id;
+												rec.Data = new float[this.STSimTransformer.Cells.Count];
+												rec.HasOutputData = false;
 
-                        this.m_SpatialOutputFlowDict.Add(ft.Id, rec);
-                    }
-                }
-            }
+												this.m_SpatialOutputFlowDict.Add(ft.Id, rec);
+										}
+								}
+						}
 
-            return this.m_SpatialOutputFlowDict;
-        }
+						return this.m_SpatialOutputFlowDict;
+				}
 
-        /// <summary>
-        /// Gets the lateral output flow dictionary
-        /// </summary>
-        /// <returns></returns>
-        /// <remarks>
-        /// We must lazy-load this dictionary because this transformer runs before ST-Sim's
-        /// and so the cell data is not there yet.
-        /// </remarks>
-        private Dictionary<int, SpatialOutputFlowRecord> GetLateralOutputFlowDictionary()
-        {
-            if (this.m_LateralOutputFlowDict == null)
-            {
-                this.m_LateralOutputFlowDict = new Dictionary<int, SpatialOutputFlowRecord>();
+				/// <summary>
+				/// Gets the lateral output flow dictionary
+				/// </summary>
+				/// <returns></returns>
+				/// <remarks>
+				/// We must lazy-load this dictionary because this transformer runs before ST-Sim's
+				/// and so the cell data is not there yet.
+				/// </remarks>
+				private Dictionary<int, SpatialOutputFlowRecord> GetLateralOutputFlowDictionary()
+				{
+						if (this.m_LateralOutputFlowDict == null)
+						{
+								this.m_LateralOutputFlowDict = new Dictionary<int, SpatialOutputFlowRecord>();
 
-                foreach (FlowType ft in this.m_FlowTypes)
-                {
-                    if (ft.OutputFilter.HasFlag(Constants.OutputFilter.Spatial) ||
-                        ft.OutputFilter.HasFlag(Constants.OutputFilter.AvgSpatial))
-                    {
-                        SpatialOutputFlowRecord rec = new SpatialOutputFlowRecord();
+								foreach (FlowType ft in this.m_FlowTypes)
+								{
+										if (ft.OutputFilter.HasFlag(Constants.OutputFilter.Spatial) ||
+												ft.OutputFilter.HasFlag(Constants.OutputFilter.AvgSpatial))
+										{
+												SpatialOutputFlowRecord rec = new SpatialOutputFlowRecord();
 
-                        rec.FlowTypeId = ft.Id;
-                        rec.Data = new float[this.STSimTransformer.Cells.Count];
-                        rec.HasOutputData = false;
+												rec.FlowTypeId = ft.Id;
+												rec.Data = new float[this.STSimTransformer.Cells.Count];
+												rec.HasOutputData = false;
 
-                        this.m_LateralOutputFlowDict.Add(ft.Id, rec);
-                    }                      
-                }
-            }
+												this.m_LateralOutputFlowDict.Add(ft.Id, rec);
+										}                      
+								}
+						}
 
-            return this.m_LateralOutputFlowDict;
-        }
+						return this.m_LateralOutputFlowDict;
+				}
 
-        /// <summary>
-        /// Get Stock Values for the specified Stock Type ID, placing then into the DblCells() in the specified raster.
-        /// </summary>
-        /// <param name="stockTypeId">The Stock Type ID that we want values for</param>
-        /// <param name="rastStockType">An object of type ApexRaster, where we will write the Stock Type values. The raster should be initialized with metadata and appropriate array sizing.</param>
-        /// <remarks></remarks>
-        private void GetStockValues(int stockTypeId, StochasticTimeRaster rastStockType)
-        {
-            double AmountPerCell = this.m_STSimTransformer.AmountPerCell;
+				/// <summary>
+				/// Get Stock Values for the specified Stock Type ID, placing then into the DblCells() in the specified raster.
+				/// </summary>
+				/// <param name="stockTypeId">The Stock Type ID that we want values for</param>
+				/// <param name="rastStockType">An object of type ApexRaster, where we will write the Stock Type values. The raster should be initialized with metadata and appropriate array sizing.</param>
+				/// <remarks></remarks>
+				private void GetStockValues(int stockTypeId, StochasticTimeRaster rastStockType)
+				{
+						double AmountPerCell = this.m_STSimTransformer.AmountPerCell;
 
-            foreach (Cell c in this.STSimTransformer.Cells)
-            {
-                Dictionary<int, float> StockAmounts = GetStockAmountDictionary(c);
+						foreach (Cell c in this.STSimTransformer.Cells)
+						{
+								Dictionary<int, float> StockAmounts = GetStockAmountDictionary(c);
 
-                if (StockAmounts.Count > 0)
-                {
-                    rastStockType.FloatCells[c.CellId] = Convert.ToSingle(StockAmounts[stockTypeId] / AmountPerCell);
-                }
-                else
-                {
-                    //I wouldnt expect to get here because of Stratum/StateClass test above
-                    Debug.Assert(false);
-                }
-            }
-        }
+								if (StockAmounts.Count > 0)
+								{
+										rastStockType.FloatCells[c.CellId] = Convert.ToSingle(StockAmounts[stockTypeId] / AmountPerCell);
+								}
+								else
+								{
+										//I wouldnt expect to get here because of Stratum/StateClass test above
+										Debug.Assert(false);
+								}
+						}
+				}
 
-        private float GetAttributeValue(
-            int stateAttributeTypeId, int stratumId, int? secondaryStratumId, int? tertiaryStratumId,
-            int stateClassId, int iteration, int timestep, int age, TstCollection cellTst)
-        {
-            float val = 0.0F;
+				private float GetAttributeValue(
+						int stateAttributeTypeId, int stratumId, int? secondaryStratumId, int? tertiaryStratumId,
+						int stateClassId, int iteration, int timestep, int age, TstCollection cellTst)
+				{
+						float val = 0.0F;
 
-            double? v = this.STSimTransformer.GetAttributeValue(
-                stateAttributeTypeId, stratumId, secondaryStratumId, tertiaryStratumId,
-                stateClassId, iteration, timestep, age, cellTst);
+						double? v = this.STSimTransformer.GetAttributeValue(
+								stateAttributeTypeId, stratumId, secondaryStratumId, tertiaryStratumId,
+								stateClassId, iteration, timestep, age, cellTst);
 
-            if (v.HasValue)
-            {
-                val = Convert.ToSingle(v.Value);
-            }
+						if (v.HasValue)
+						{
+								val = Convert.ToSingle(v.Value);
+						}
 
-            return val;
-        }
+						return val;
+				}
 
-        protected bool AnyOutputOptionsSelected()
+				protected bool AnyOutputOptionsSelected()
 		{
 			DataRow dr = this.ResultScenario.GetDataSheet(Constants.DATASHEET_OO_NAME).GetDataRow();
 
@@ -173,11 +173,11 @@ namespace SyncroSim.STSimStockFlow
 			}
 
 			if (DataTableUtilities.GetDataBool(
-                dr, Constants.DATASHEET_OO_SUMMARY_OUTPUT_ST_COLUMN_NAME) || 
-                DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_SUMMARY_OUTPUT_FL_COLUMN_NAME) || 
-                DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_SPATIAL_OUTPUT_ST_COLUMN_NAME) ||
-                DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_SPATIAL_OUTPUT_FL_COLUMN_NAME) ||
-                DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_LATERAL_OUTPUT_FL_COLUMN_NAME))
+								dr, Constants.DATASHEET_OO_SUMMARY_OUTPUT_ST_COLUMN_NAME) || 
+								DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_SUMMARY_OUTPUT_FL_COLUMN_NAME) || 
+								DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_SPATIAL_OUTPUT_ST_COLUMN_NAME) ||
+								DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_SPATIAL_OUTPUT_FL_COLUMN_NAME) ||
+								DataTableUtilities.GetDataBool(dr, Constants.DATASHEET_OO_LATERAL_OUTPUT_FL_COLUMN_NAME))
 			{
 				return true;
 			}
@@ -213,180 +213,180 @@ namespace SyncroSim.STSimStockFlow
 			return true;
 		}
 
-        protected bool IsStockLimitsOnSourceAndTarget()
-        {
-            DataTable stockLims = this.ResultScenario.GetDataSheet(Constants.DATASHEET_STOCK_LIMIT_NAME).GetData();
-            // this.ResultScenario.DataFeeds.GetDataSheet(Constants.DATASHEET_STOCK_LIMIT_NAME);
-            return false;
-        }
+				protected bool IsStockLimitsOnSourceAndTarget()
+				{
+						DataTable stockLims = this.ResultScenario.GetDataSheet(Constants.DATASHEET_STOCK_LIMIT_NAME).GetData();
+						// this.ResultScenario.DataFeeds.GetDataSheet(Constants.DATASHEET_STOCK_LIMIT_NAME);
+						return false;
+				}
 
-        private List<List<FlowType>> CreateListOfFlowTypeLists()
-        {
-            List<List<FlowType>> FlowTypeLists = new List<List<FlowType>>();
+				private List<List<FlowType>> CreateListOfFlowTypeLists()
+				{
+						List<List<FlowType>> FlowTypeLists = new List<List<FlowType>>();
 
-            if (this.m_ApplyEquallyRankedSimultaneously)
-            {
-                SortedDictionary<double, List<FlowType>> FlowTypeOrderDictionary = new SortedDictionary<double, List<FlowType>>();
+						if (this.m_ApplyEquallyRankedSimultaneously)
+						{
+								SortedDictionary<double, List<FlowType>> FlowTypeOrderDictionary = new SortedDictionary<double, List<FlowType>>();
 
-                foreach (FlowType ft in this.m_ShufflableFlowTypes)
-                {
-                    if (!FlowTypeOrderDictionary.ContainsKey(ft.Order))
-                    {
-                        FlowTypeOrderDictionary.Add(ft.Order, new List<FlowType>());
-                    }
+								foreach (FlowType ft in this.m_ShufflableFlowTypes)
+								{
+										if (!FlowTypeOrderDictionary.ContainsKey(ft.Order))
+										{
+												FlowTypeOrderDictionary.Add(ft.Order, new List<FlowType>());
+										}
 
-                    FlowTypeOrderDictionary[ft.Order].Add(ft);
-                }
+										FlowTypeOrderDictionary[ft.Order].Add(ft);
+								}
 
-                foreach (double order in FlowTypeOrderDictionary.Keys)
-                {
-                    List<FlowType> l = FlowTypeOrderDictionary[order];
-                    FlowTypeLists.Add(l);
-                }
-            }
-            else
-            {
-                foreach (FlowType ft in this.m_ShufflableFlowTypes)
-                {
-                    List<FlowType> l = new List<FlowType>();
-                    l.Add(ft);
-                    FlowTypeLists.Add(l);
-                }
-            }
+								foreach (double order in FlowTypeOrderDictionary.Keys)
+								{
+										List<FlowType> l = FlowTypeOrderDictionary[order];
+										FlowTypeLists.Add(l);
+								}
+						}
+						else
+						{
+								foreach (FlowType ft in this.m_ShufflableFlowTypes)
+								{
+										List<FlowType> l = new List<FlowType>();
+										l.Add(ft);
+										FlowTypeLists.Add(l);
+								}
+						}
 
-            return (FlowTypeLists);
-        }
+						return (FlowTypeLists);
+				}
 
-        private bool FilterIncludesTabularDataForStockGroup(int stockGroupId)
-        {
-            if (!this.m_OutputFilterStocks.HasItems)
-            {
-                return true;
-            }
+				private bool FilterIncludesTabularDataForStockGroup(int stockGroupId)
+				{
+						if (!this.m_OutputFilterStocks.HasItems)
+						{
+								return true;
+						}
 
-            OutputFilterStocks flt = (OutputFilterStocks)this.m_OutputFilterStocks.Get(stockGroupId);
+						OutputFilterStocks flt = (OutputFilterStocks)this.m_OutputFilterStocks.Get(stockGroupId);
 
-            if (flt == null)
-            {
-                return false;
-            }
+						if (flt == null)
+						{
+								return false;
+						}
 
-            return flt.OutputTabularData;
-        }
+						return flt.OutputTabularData;
+				}
 
-        private bool FilterIncludesSpatialDataForStockGroup(int stockGroupId)
-        {
-            if (!this.m_OutputFilterStocks.HasItems)
-            {
-                return true;
-            }
+				private bool FilterIncludesSpatialDataForStockGroup(int stockGroupId)
+				{
+						if (!this.m_OutputFilterStocks.HasItems)
+						{
+								return true;
+						}
 
-            OutputFilterStocks flt = (OutputFilterStocks)this.m_OutputFilterStocks.Get(stockGroupId);
+						OutputFilterStocks flt = (OutputFilterStocks)this.m_OutputFilterStocks.Get(stockGroupId);
 
-            if (flt == null)
-            {
-                return false;
-            }
+						if (flt == null)
+						{
+								return false;
+						}
 
-            return flt.OutputSpatialData;
-        }
+						return flt.OutputSpatialData;
+				}
 
-        private bool FilterIncludesAvgSpatialDataForStockGroup(int stockGroupId)
-        {
-            if (!this.m_OutputFilterStocks.HasItems)
-            {
-                return true;
-            }
+				private bool FilterIncludesAvgSpatialDataForStockGroup(int stockGroupId)
+				{
+						if (!this.m_OutputFilterStocks.HasItems)
+						{
+								return true;
+						}
 
-            OutputFilterStocks flt = (OutputFilterStocks)this.m_OutputFilterStocks.Get(stockGroupId);
+						OutputFilterStocks flt = (OutputFilterStocks)this.m_OutputFilterStocks.Get(stockGroupId);
 
-            if (flt == null)
-            {
-                return false;
-            }
+						if (flt == null)
+						{
+								return false;
+						}
 
-            return flt.OutputAvgSpatialData;
-        }
+						return flt.OutputAvgSpatialData;
+				}
 
-        private bool FilterIncludesTabularDataForFlowGroup(int flowGroupId)
-        {
-            if (!this.m_OutputFilterFlows.HasItems)
-            {
-                return true;
-            }
+				private bool FilterIncludesTabularDataForFlowGroup(int flowGroupId)
+				{
+						if (!this.m_OutputFilterFlows.HasItems)
+						{
+								return true;
+						}
 
-            OutputFilterFlows flt = (OutputFilterFlows)this.m_OutputFilterFlows.Get(flowGroupId);
+						OutputFilterFlows flt = (OutputFilterFlows)this.m_OutputFilterFlows.Get(flowGroupId);
 
-            if (flt == null)
-            {
-                return false;
-            }
+						if (flt == null)
+						{
+								return false;
+						}
 
-            return flt.OutputTabularData;
-        }
+						return flt.OutputTabularData;
+				}
 
-        private bool FilterIncludesSpatialDataForFlowGroup(int flowGroupId)
-        {
-            if (!this.m_OutputFilterFlows.HasItems)
-            {
-                return true;
-            }
+				private bool FilterIncludesSpatialDataForFlowGroup(int flowGroupId)
+				{
+						if (!this.m_OutputFilterFlows.HasItems)
+						{
+								return true;
+						}
 
-            OutputFilterFlows flt = (OutputFilterFlows)this.m_OutputFilterFlows.Get(flowGroupId);
+						OutputFilterFlows flt = (OutputFilterFlows)this.m_OutputFilterFlows.Get(flowGroupId);
 
-            if (flt == null)
-            {
-                return false;
-            }
+						if (flt == null)
+						{
+								return false;
+						}
 
-            return flt.OutputSpatialData;
-        }
+						return flt.OutputSpatialData;
+				}
 
-        private bool FilterIncludesAvgSpatialDataForFlowGroup(int flowGroupId)
-        {
-            if (!this.m_OutputFilterFlows.HasItems)
-            {
-                return true;
-            }
+				private bool FilterIncludesAvgSpatialDataForFlowGroup(int flowGroupId)
+				{
+						if (!this.m_OutputFilterFlows.HasItems)
+						{
+								return true;
+						}
 
-            OutputFilterFlows flt = (OutputFilterFlows)this.m_OutputFilterFlows.Get(flowGroupId);
+						OutputFilterFlows flt = (OutputFilterFlows)this.m_OutputFilterFlows.Get(flowGroupId);
 
-            if (flt == null)
-            {
-                return false;
-            }
+						if (flt == null)
+						{
+								return false;
+						}
 
-            return flt.OutputAvgSpatialData;
-        }
+						return flt.OutputAvgSpatialData;
+				}
 
-        private bool FilterIncludesSpatialDataForFlowType(int flowTypeId)
-        {
-            FlowType ft = this.m_FlowTypes[flowTypeId];
+				private bool FilterIncludesSpatialDataForFlowType(int flowTypeId)
+				{
+						FlowType ft = this.m_FlowTypes[flowTypeId];
 
-            foreach (FlowGroupLinkage l in ft.FlowGroupLinkages)
-            {
-                if (this.FilterIncludesSpatialDataForFlowGroup(l.FlowGroup.Id))
-                {
-                    return true;
-                }
-            }
+						foreach (FlowGroupLinkage l in ft.FlowGroupLinkages)
+						{
+								if (this.FilterIncludesSpatialDataForFlowGroup(l.FlowGroup.Id))
+								{
+										return true;
+								}
+						}
 
-            return false;
-        }
+						return false;
+				}
 
-        private bool FilterIncludesAvgSpatialDataForFlowType(int flowTypeId)
-        {
-            FlowType ft = this.m_FlowTypes[flowTypeId];
+				private bool FilterIncludesAvgSpatialDataForFlowType(int flowTypeId)
+				{
+						FlowType ft = this.m_FlowTypes[flowTypeId];
 
-            foreach (FlowGroupLinkage l in ft.FlowGroupLinkages)
-            {
-                if (this.FilterIncludesAvgSpatialDataForFlowGroup(l.FlowGroup.Id))
-                {
-                    return true;
-                }
-            }
+						foreach (FlowGroupLinkage l in ft.FlowGroupLinkages)
+						{
+								if (this.FilterIncludesAvgSpatialDataForFlowGroup(l.FlowGroup.Id))
+								{
+										return true;
+								}
+						}
 
-            return false;
-        }
-    }
+						return false;
+				}
+		}
 }


### PR DESCRIPTION
Fixes the following issues in the stock flow rasters:

1. Extra division by cell size in average flow rasters
2. -9999 (NO DATA) cells being included in raster cell amount calculation
3. Average stock and flow raster calculations not including scaling by stock group membership and flow group membership values
4. NaNs being included in output rasters when initial stock rasters have no data value set to NaN

Note: for the NaN fix, must use SyncroSim v2.4.40+