### PR TITLE
vz update deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 **stsimsf** is an open-source [SyncroSim](http://www.syncrosim.com) add-on package to [ST-Sim](https://docs.stsim.net/) for integrating stocks and flows into state-and-transition simulation models. 
 
-Note that the *stsimsf* package is deprecated as of the release of <a href="https://syncrosim.com/download/" target="_blank">SyncroSim 3</a>, as the stocks and flows functionality is now fully integrated with <a href="https://docs.stsim.net/" target="_blank">ST-Sim</a> 
+Note that the *stsimsf* package is deprecated as of the release of <a href="https://syncrosim.com/download/" target="_blank">SyncroSim 3</a>, as the stocks and flows functionality is now fully integrated with <a href="https://docs.stsim.net/" target="_blank">ST-Sim</a>.
 
 * See the [Home page](https://apexrms.github.io/stsimsf/) for an overview of **stsimsf**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # **stsimsf**
 
-**stsimsf** is an open-source [SyncroSim](http://www.syncrosim.com) add-on package to [ST-Sim](https://docs.stsim.net/) for integrating stocks and flows into state-and-transition simulation models.
+**stsimsf** is an open-source [SyncroSim](http://www.syncrosim.com) add-on package to [ST-Sim](https://docs.stsim.net/) for integrating stocks and flows into state-and-transition simulation models. 
+
+Note that the *stsimsf* package is deprecated as of the release of <a href="https://syncrosim.com/download/" target="_blank">SyncroSim 3</a>, as the stocks and flows functionality is now fully integrated with <a href="https://docs.stsim.net/" target="_blank">ST-Sim</a> 
 
 * See the [Home page](https://apexrms.github.io/stsimsf/) for an overview of **stsimsf**

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,8 @@ permalink: /
 <a href="http://doi.org/10.1111/2041-210X.12597" target="_blank">State-and-transition simulation models</a> (STSMs) are used to forecast landscape dynamics. Using the base SyncroSim package, <a href="https://docs.stsim.net/" target="_blank">*ST-Sim*</a>, you can design models to forecast the change of discrete variables, such as the expansion/contraction of agricultural lands or harvest of tree plantations (see <a href="http://doi.org/10.1111/2041-210X.12597" target="_blank">Daniel, Frid, Sleeter, and Fortin (2016)</a>). Using the ST-Sim Add-On package, *stsimsf*, you can design models to forecast the change of continuous variables as well, such as biomass and carbon fluctuations. For more information on integrating STSMs with stock-flow models, see the paper by <a href="http://doi.org/10.1111/2041-210X.12952" target="_blank">Daniel, Sleeter, Frid, and Fortin (2018)</a>.
 <br>
 
+**The *stsimsf* package is now deprecated, and the stocks and flows functionality is fully integrated with <a href="https://docs.stsim.net/" target="_blank">ST-Sim</a> for <a href="https://syncrosim.com/download/" target="_blank">SyncroSim 3</a>.**
+
 ## Requirements
 
 This package requires:


### PR DESCRIPTION
Update the README and the home page with a warning that stsimsf is now deprecated as it has been integrated with st-sim for SyncroSim 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation notice: stsimsf is deprecated for SyncroSim 3; stocks/flows functionality is now integrated with ST-Sim. The notice has been added to user-facing documentation (placed before requirements) to guide users to the integrated workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->